### PR TITLE
Use pyzipper module to support decrypt AES encrypted file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 colorama
+pyzipper

--- a/zz.py
+++ b/zz.py
@@ -13,6 +13,7 @@ from colorama import Fore,Back,Style,init
 from itertools import chain,product
 from optparse import OptionParser
 from zipfile import ZipFile
+from pyzipper import AESZipFile
 import string
 import signal
 import time
@@ -69,7 +70,7 @@ class main():
     def wlist_crack_entry(self, archive_dir, wordlist_inp, showoutput_b, resume_index):
         tries = 0
         try:
-            try: _archive = ZipFile(archive_dir, "r")
+            try: _archive = AESZipFile(archive_dir, "r")
             except Exception as ex: print(ex); sys.exit(1)
 
             print("Loading Wordlist, Please wait")
@@ -132,7 +133,7 @@ class main():
     def bruteforce_crack_entry(self, archive_dir, charset, max_letters, showoutput_b, resume_index):
         tries = 0
         try:
-            try: _archive = ZipFile(archive_dir, "r")
+            try: _archive = AESZipFile(archive_dir, "r")
             except Exception as ex: print(ex); sys.exit(1)
             print("Started...")
             self.bruteforce_crack(tries,None,_archive,showoutput_b, charset, max_letters)


### PR DESCRIPTION
At the start, I try to use `zzCrack` to crack an AES-encrypted zip file, and I found it does not work.

As this answer mentioned [Python unzip AES-128 encrypted file](https://stackoverflow.com/questions/15553150/python-unzip-aes-128-encrypted-file), Python's `zipfile` module actually does not support reading zip files with AES, so I try to use [pyzipper](https://github.com/danifus/pyzipper) module to replace it.

In my test, I use BandiZip to compress a zip file with AES encryption, this is my configuration:
![zipConfig](https://github.com/robiot/zzCrack/assets/24267374/ff473975-109a-46d9-aa2c-6f5b1f88807f )

This is the result, the `pyzipper` replaced version successfully found the password.
![image](https://github.com/robiot/zzCrack/assets/24267374/ea188d19-3093-46b5-81e1-59093bec83b6)


Although when treating with the default ZipCrypto file, the `pyzipper` version seems has 20% performance degradation, I am considering whether has a way to check the encryption type of zip file or we need a configuration to control it.
![1684331122077](https://github.com/robiot/zzCrack/assets/24267374/53795059-b11f-46d4-9b50-253a02800b2f)

